### PR TITLE
Use tdr-configurations to remove dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ python/__pycache__/
 
 # module directories
 tdr-terraform-modules
+tdr-configurations

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -24,6 +24,9 @@ pipeline {
                     steps {
                         echo 'Initializing Terraform...'
                         sh "git clone https://github.com/nationalarchives/tdr-terraform-modules.git"
+                        sshagent(['github-jenkins']) {
+                            sh("git clone git@github.com:nationalarchives/tdr-configurations.git")
+                        }
                         sh 'terraform init'
                         //If Terraform workspace exists continue
                         sh "terraform workspace new ${params.STAGE} || true"

--- a/README.md
+++ b/README.md
@@ -29,7 +29,8 @@ terraform init
 terraform workspace select mgmt
 terraform plan
 ```
-* if the Route53 hosted zone has been created manually, before applying terraform, e.g.:
+* if the Route53 hosted zone has been created manually, uncomment the name server block in terraform modules
+* then run Terraform commands as below
 ```
 terraform import module.route_53_zone.aws_route53_zone.hosted_zone Z4KAPRWWNC7JR
 terraform import module.route_53_zone.aws_route53_record.hosted_zone_ns Z4KAPRWWNC7JR_tdr-management.nationalarchives.gov.uk_NS_tdr-management
@@ -67,6 +68,10 @@ terraform apply
 
 ### Deploy Terraform to Integration and Production environments
 * Deploy using Jenkins pipeline
+* The last stage of the Terraform build (SES verification) may time out
+* If so, stop the build
+* Delegate from corporate DNS to the AWS hosted zone name servers
+* Then rerun the pipeline
 
 ## USAGE - PYTHON
 
@@ -77,7 +82,6 @@ terraform apply
 ```
 virtualenv -p python3 /Users/YOUR-USERNAME/venv
 ```
-
 * Activate virtual environment
 ```
 source /Users/YOUR-USERNAME/venv/python3/bin/activate

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ terraform init
 terraform workspace select mgmt
 terraform plan
 ```
-* if the Route53 hosted zone has been created manually, uncomment the name server block in terraform modules
+* if the Route53 hosted zone has been created manually, ensure the environment is included in the name server block conditional [here](https://github.com/nationalarchives/tdr-terraform-modules/blob/master/route53/main.tf)
 * then run Terraform commands as below
 ```
 terraform import module.route_53_zone.aws_route53_zone.hosted_zone Z4KAPRWWNC7JR

--- a/README.md
+++ b/README.md
@@ -68,10 +68,9 @@ terraform apply
 
 ### Deploy Terraform to Integration and Production environments
 * Deploy using Jenkins pipeline
-* The last stage of the Terraform build (SES verification) may time out
-* If so, stop the build
-* Delegate from corporate DNS to the AWS hosted zone name servers
-* Then rerun the pipeline
+* If this is the first time in a new environment, request DNS delegation for the hosted zone
+* Once in place, modify the conditional statements [here](https://github.com/nationalarchives/tdr-terraform-modules/blob/master/ses/main.tf)
+* then rerun the pipeline for that environment 
 
 ## USAGE - PYTHON
 

--- a/root_data.tf
+++ b/root_data.tf
@@ -1,7 +1,0 @@
-data "aws_ssm_parameter" "cost_centre" {
-  name = "/mgmt/cost_centre"
-}
-
-data "aws_ssm_parameter" "trusted_ips" {
-  name = "/mgmt/trusted_ips"
-}

--- a/root_locals.tf
+++ b/root_locals.tf
@@ -13,8 +13,8 @@ locals {
     "Environment", local.environment,
     "Owner", "TDR",
     "Terraform", true,
-    "CostCentre", data.aws_ssm_parameter.cost_centre.value,
+    "CostCentre", module.global_parameters.cost_centre,
   )
   region = "eu-west-2"
-  ip_set = data.aws_ssm_parameter.trusted_ips.value
+  ip_set = module.global_parameters.trusted_ips
 }

--- a/root_main.tf
+++ b/root_main.tf
@@ -1,3 +1,7 @@
+module "global_parameters" {
+  source            = "./tdr-configurations/terraform"
+}
+
 module "iam" {
   source            = "./tdr-terraform-modules/iam"
   aws_account_level = true


### PR DESCRIPTION
Use tdr-configurations private repo to store non-confidential parameters, updates for hosted zones which have been manually created, and before and after DNS delegation