### PR TITLE
Move SES region

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,12 +7,17 @@ There are two scripting languages used:
 
 Code using each language is deployed separately, see sections below.
 
-## Account level configurations
-* Sets IAM password policy to comply with CIS AWS Foundation Benchmark (terraform)
-* Configures GuardDuty and enables in all regions (terraform)
-* Turns on Config in all regions (terraform)
-* Configures CloudTrail at AWS account level (terraform)
-* Deletes default VPCs in all regions (python)
+## Account level configurations - Terraform
+* Sets IAM password policy to comply with CIS AWS Foundation Benchmark
+* Configures GuardDuty and enables in all regions
+* Turns on Config in all regions
+* Configures CloudTrail at AWS account level
+* Configures Securty Hub
+* Creates hosted zone
+* Creates Simple Email Service
+
+## Account level configurations - Python
+* Deletes default VPCs in all regions
 
 ## USAGE - TERRAFORM
 

--- a/root_main.tf
+++ b/root_main.tf
@@ -27,9 +27,6 @@ module "ses-eu-west-1" {
   hosted_zone_id        = module.route_53_zone.hosted_zone_id
   #if building a new environment, uncomment the line below and replace xxxx with new workspace name
   #dns_delegated         = local.environment == "xxxx" ? false : true
-  providers = {
-    aws = aws.eu-west-1
-  }
 }
 
 module "security_hub" {
@@ -59,5 +56,5 @@ module "cloudtrail" {
   project        = var.project
   common_tags    = local.common_tags
   s3_bucket_name = module.cloudtrail_s3.s3_bucket_id
-  kms_key_id     = module.encryption_key.kms_alias_arn
+  kms_key_id     = module.encryption_key.kms_key_arn
 }


### PR DESCRIPTION
Amazon Simple Email Service (SES) is now available in the eu-west-2 London region.

This update moves SES from eu-west-1 to eu-west-2 so that all infrastructure is in a single region.