### PR TITLE
Update the AWS provider version.

### DIFF
--- a/root_provider.tf
+++ b/root_provider.tf
@@ -1,6 +1,6 @@
 provider "aws" {
   region = "eu-west-2"
-  version = 2.58
+  version = 2.69
   assume_role {
     role_arn     = local.assume_role
     session_name = "terraform"


### PR DESCRIPTION
Some of the fields in the terraform-modules project don't exist in the
older version so it needs upgrading to be able to run.