### PR TITLE
Reinitialize Terraform after workspace selected

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -47,6 +47,11 @@ pipeline {
         stage('Run Terraform plan') {
           steps {
             echo 'Running Terraform plan...'
+            //Require reinitialization of Terraform after workspace is selected when upgrading from v12 to v13
+            //See this thread for details of the issue: https://discuss.hashicorp.com/t/terraform-v0-13-failed-to-instantiate-provider-for-every-project/16522/9
+            //This step should not be necessary when upgrading from v13 upwards
+            sh 'terraform init'
+
             sh 'terraform plan'
             script {
               tdr.postToDaTdrSlackChannel(colour: "good",


### PR DESCRIPTION
Reinitialization needed when upgrading from Terraform v12 to v13

See thread here for details of the issue: https://discuss.hashicorp.com/t/terraform-v0-13-failed-to-instantiate-provider-for-every-project/16522

Reinitialization was the suggested way around the issue: https://discuss.hashicorp.com/t/terraform-v0-13-failed-to-instantiate-provider-for-every-project/16522/9

This should not be necessary when upgrade from Terraform v13 upwards so can be removed in the future