### PR TITLE
Add log lambda timeout parameter

### DIFF
--- a/root_main.tf
+++ b/root_main.tf
@@ -76,6 +76,7 @@ module "lambda_s3_copy" {
   project            = var.project
   common_tags        = local.common_tags
   lambda_log_data    = true
+  timeout_seconds    = 30
   log_data_sns_topic = module.log_data_sns.sns_arn
   target_s3_bucket   = "${var.project}-log-data-mgmt"
   kms_key_arn        = module.encryption_key.kms_key_arn


### PR DESCRIPTION
This value was moved out of tdr-terraform-modules to make it easier for tdr-terraform-environments to use the file format lambda timeouts in other modules.

The log lambda uses a non-default timeout, so it now has to pass it to the lambda module.