### PR TITLE
Added sandbox to the list of environments the log data queue is created in

### DIFF
--- a/root_main.tf
+++ b/root_main.tf
@@ -44,7 +44,7 @@ module "encryption_key" {
 
 module "log_data_sns" {
   source         = "./tdr-terraform-modules/sns"
-  apply_resource = local.environment == "mgmt" || local.environment == "intg" || local.environment == "staging" || local.environment == "prod" ? true : false
+  apply_resource = local.environment == "mgmt" || local.environment == "intg" || local.environment == "staging" || local.environment == "prod" || local.environment == "sbox" ? true : false
   project        = var.project
   common_tags    = local.common_tags
   function       = "logs"


### PR DESCRIPTION
This queue is used for s3 notifications for AWS config. As this wasn't
being created, some of the other resources which relied on it were
erroring.

I did think of removing the if condition altogether but there is a ddri
workspace on this account so I've added in the sandbox environment
instead.
