### PR TITLE
CLOP-12 updates for Data Preservation

### DIFF
--- a/.github/workflows/apply.yml
+++ b/.github/workflows/apply.yml
@@ -41,12 +41,12 @@ jobs:
     runs-on: ubuntu-latest
     needs: setup
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           submodules: recursive
           token: ${{ secrets[needs.setup.outputs.workflow-token] }}
       - name: Configure AWS credentials for Lambda
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v4
         with:
           role-to-assume: ${{ secrets[needs.setup.outputs.terraform-role] }}
           aws-region: eu-west-2

--- a/root_main.tf
+++ b/root_main.tf
@@ -99,7 +99,7 @@ module "lambda_s3_copy" {
       bucket_name = "${var.project}-log-data-${local.environment}"
     })
   }
-  runtime = "python3.9"
+  runtime = "python3.11"
   tags    = local.common_tags
   lambda_invoke_permissions = {
     "sns.amazonaws.com" = module.log_data_sns.sns_arn
@@ -109,7 +109,7 @@ module "lambda_s3_copy" {
 }
 
 module "log_data_s3" {
-  count       = local.environment == "mgmt" ? 1 : 0
+  count       = local.environment == "mgmt" || var.project == "dr2" ? 1 : 0
   source      = "./da-terraform-modules/s3"
   bucket_name = "${var.project}-log-data-${local.environment}"
   bucket_policy = templatefile("./templates/s3/log-data-policy.json.tpl", {


### PR DESCRIPTION
- don't destroy Athena S3 buckets in Digital Preservation AWS accounts
- upgrade Python runtime to 3.11 on S3 copy Lambda to reflect change presumably made manually