### PR TITLE
fix: Confused deputy for S3 cloudtrail bucket policy

### DIFF
--- a/root_data.tf
+++ b/root_data.tf
@@ -5,3 +5,5 @@ data "archive_file" "log_data_lambda" {
 }
 
 data "aws_caller_identity" "current" {}
+data "aws_region" "current" {}
+data "aws_partition" "current" {}

--- a/root_main.tf
+++ b/root_main.tf
@@ -65,7 +65,10 @@ module "cloudtrail_s3" {
   source      = "./da-terraform-modules/s3"
   bucket_name = local.cloudtrail_bucket
   bucket_policy = templatefile("./templates/s3/cloudtrail.json.tpl", {
-    bucket_name = local.cloudtrail_bucket
+    bucket_name   = local.cloudtrail_bucket
+    aws_partition = data.aws_partition.current.id
+    aws_region    = data.aws_region.current.name
+    account_id    = data.aws_caller_identity.current.id
   })
   create_log_bucket = false
   common_tags       = local.common_tags

--- a/templates/s3/cloudtrail.json.tpl
+++ b/templates/s3/cloudtrail.json.tpl
@@ -20,7 +20,8 @@
       "Resource": "arn:aws:s3:::${bucket_name}/*",
       "Condition": {
         "StringEquals": {
-          "s3:x-amz-acl": "bucket-owner-full-control"
+          "s3:x-amz-acl": "bucket-owner-full-control",
+          "AWS:SourceArn": "arn:${aws_partition}:cloudtrail:${aws_region}:${account_id}:trail/*"
         }
       }
     }

--- a/templates/s3/cloudtrail.json.tpl
+++ b/templates/s3/cloudtrail.json.tpl
@@ -19,9 +19,11 @@
       "Action": "s3:PutObject",
       "Resource": "arn:aws:s3:::${bucket_name}/*",
       "Condition": {
-        "StringEquals": {
-          "s3:x-amz-acl": "bucket-owner-full-control",
+        "StringLike": {
           "AWS:SourceArn": "arn:${aws_partition}:cloudtrail:${aws_region}:${account_id}:trail/*"
+        },
+        "StringEquals": {
+          "s3:x-amz-acl": "bucket-owner-full-control"
         }
       }
     }


### PR DESCRIPTION
Working as expected in int.
Object ACL also disabled by hand for the bucket (Now the AWS default)